### PR TITLE
Fix write reliability and improve legacy CANBoard compatibility

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run dingoConfig (web)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build dingoConfig",
+      "program": "${workspaceFolder}/web/bin/Debug/net10.0/dingoConfig.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/web",
+      "stopAtEntry": false,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,63 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "check dotnet sdk",
+      "type": "process",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}/check-dotnet.ps1"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "sync testing branch",
+      "type": "process",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}/sync-testing-branch.ps1",
+        "-TargetPath",
+        "${workspaceFolder}"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "build dingoConfig",
+      "type": "process",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}/build-local.ps1"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "run dingoConfig",
+      "type": "process",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "${workspaceFolder}/run-local.ps1"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -22,3 +22,27 @@ dingoConfig is fully cross platform:
 # [**Documentation**](https://corygrant.github.io/dingoPDM/software/introduction/)
 
 ![Screenshot](./screenshot.png)
+
+## VS Code local build (testing branch)
+
+This repository includes ready-to-use scripts and VS Code tasks for local development on Windows:
+
+- `sync-testing-branch.ps1` - clone/sync latest `origin/testing`
+- `build-local.ps1` - restore + build `dingoConfig.sln`
+- `run-local.ps1` - run `web/web.csproj`
+
+### Quick start in VS Code
+
+1. Open this repository folder in VS Code.
+2. Run `Terminal -> Run Task... -> build dingoConfig` (or `Ctrl+Shift+B`).
+   - This first syncs `testing`, then restores/builds.
+3. Press `F5` and choose `Run dingoConfig (web)`.
+
+### One-off PowerShell usage
+
+```powershell
+.\sync-testing-branch.ps1 -TargetPath "$HOME\dingoConfig"
+cd "$HOME\dingoConfig"
+.\build-local.ps1
+.\run-local.ps1
+```

--- a/build-local.ps1
+++ b/build-local.ps1
@@ -1,0 +1,56 @@
+param(
+    [string]$SolutionPath = ".\dingoConfig.sln"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-DotnetWithNet10 {
+    $candidates = @(
+        "$env:ProgramFiles\dotnet\dotnet.exe",
+        "${env:ProgramFiles(x86)}\dotnet\dotnet.exe"
+    ) | Where-Object { Test-Path $_ }
+
+    foreach ($candidate in $candidates) {
+        $sdks = & $candidate --list-sdks 2>$null
+        if ($LASTEXITCODE -ne 0) { continue }
+        if ($sdks -match '^\s*10\.') {
+            return $candidate
+        }
+    }
+
+    $commandDotnet = (Get-Command dotnet -ErrorAction SilentlyContinue).Source
+    if ($commandDotnet) {
+        $sdks = & $commandDotnet --list-sdks 2>$null
+        if (($LASTEXITCODE -eq 0) -and ($sdks -match '^\s*10\.')) {
+            return $commandDotnet
+        }
+    }
+
+    return $null
+}
+
+$dotnetExe = Resolve-DotnetWithNet10
+if (-not $dotnetExe) {
+    Write-Error "No .NET 10 SDK found. Install .NET 10 SDK and ensure it is available under Program Files\dotnet."
+    exit 1
+}
+
+Write-Host "Using dotnet: $dotnetExe" -ForegroundColor Cyan
+$sdkVersion = (& $dotnetExe --version).Trim()
+Write-Host "Detected SDK: $sdkVersion" -ForegroundColor Cyan
+
+Write-Host "Restoring packages..." -ForegroundColor Cyan
+& $dotnetExe restore $SolutionPath
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "dotnet restore failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+Write-Host "Building solution..." -ForegroundColor Cyan
+& $dotnetExe build $SolutionPath --no-restore
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "dotnet build failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+Write-Host "Build completed successfully." -ForegroundColor Green

--- a/check-dotnet.ps1
+++ b/check-dotnet.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = "Stop"
+
+$candidates = @(
+    "$env:ProgramFiles\dotnet\dotnet.exe",
+    "${env:ProgramFiles(x86)}\dotnet\dotnet.exe"
+) | Where-Object { Test-Path $_ }
+
+Write-Host "Detected dotnet executables:" -ForegroundColor Cyan
+foreach ($candidate in $candidates) {
+    Write-Host " - $candidate"
+    & $candidate --version
+    & $candidate --list-sdks
+    Write-Host ""
+}
+
+$commandDotnet = (Get-Command dotnet -ErrorAction SilentlyContinue).Source
+if ($commandDotnet) {
+    Write-Host "PATH dotnet command:" -ForegroundColor Cyan
+    Write-Host " - $commandDotnet"
+    & $commandDotnet --version
+    & $commandDotnet --list-sdks
+}
+else {
+    Write-Error "dotnet command not found in PATH."
+    exit 1
+}

--- a/domain/Devices/FwDevice.cs
+++ b/domain/Devices/FwDevice.cs
@@ -22,7 +22,9 @@ public class FwDevice : IDeviceConfigurable
     [JsonPropertyName("type")] public string Type { get; set; }
     [JsonPropertyName("deviceType")] public int DeviceTypeId { get; set; }
     [JsonIgnore] protected bool DeviceTypeOk;
-    [JsonIgnore] public bool ConfigMismatch { get; set; } = true;
+    // Older firmware may not support CheckCrcRsp. Default to "no mismatch"
+    // until we receive an explicit CRC response.
+    [JsonIgnore] public bool ConfigMismatch { get; set; } = false;
 
     [JsonIgnore] public Guid Guid { get; }
     [JsonIgnore] public int ConfigVersion { get; set; }
@@ -72,6 +74,7 @@ public class FwDevice : IDeviceConfigurable
     [JsonIgnore] private Dictionary<string, Action<int, double>> _indexedSetters = new();
 
     [JsonIgnore] private ParamProtocol _paramProtocol = null!;
+    [JsonIgnore] private bool _legacyCanboardIdLayout;
 
     [JsonIgnore]
     public bool Connected
@@ -412,6 +415,10 @@ public class FwDevice : IDeviceConfigurable
 
     private void Clear()
     {
+        // Reset stale mismatch state when link drops; it will be re-evaluated
+        // when CRC responses are received after reconnect.
+        ConfigMismatch = false;
+
         foreach(var input in DigitalInputs)
             input.State = false;
 
@@ -460,8 +467,15 @@ public class FwDevice : IDeviceConfigurable
     {
         var offset = id - BaseId;
 
+        // Legacy CANBoard firmware/layout may publish cyclic frames starting at BaseId,
+        // while newer protocol expects cyclic frames at BaseId + 2.
+        if (Def.DeviceType == 3 && id == BaseId)
+            _legacyCanboardIdLayout = true;
+
+        var cyclicRxOffset = _legacyCanboardIdLayout ? 0 : CyclicRxOffset;
+
         // Use dictionary lookup for status messages
-        if (CyclicSigs.TryGetValue(offset - CyclicRxOffset, out var signals))
+        if (CyclicSigs.TryGetValue(offset - cyclicRxOffset, out var signals))
         {
             foreach (var (signal, setValue) in signals)
             {
@@ -658,8 +672,13 @@ public class FwDevice : IDeviceConfigurable
 
     public DeviceCanFrame GetVersionMsg()
     {
+        // Legacy CANBoard firmware may not respond to Version requests.
+        // Send as fire-and-forget to avoid retry/error noise in read-only mode.
+        var expectResponse = Def.DeviceType != 3;
+
         return new DeviceCanFrame
         {
+            SendOnly = !expectResponse,
             DeviceBaseId = BaseId,
             Frame = new CanFrame
             (

--- a/infrastructure/Adapters/PcanAdapter.cs
+++ b/infrastructure/Adapters/PcanAdapter.cs
@@ -75,7 +75,15 @@ public class PcanAdapter  : ICommsAdapter
     public Task<bool> WriteBatchAsync(IReadOnlyList<CanFrame> frames, CancellationToken ct)
     {
         foreach (var frame in frames)
-            WriteAsync(frame, ct);
+        {
+            if (ct.IsCancellationRequested)
+                return Task.FromResult(false);
+
+            var success = WriteAsync(frame, ct).Result;
+            if (!success)
+                return Task.FromResult(false);
+        }
+
         return Task.FromResult(true);
     }
 

--- a/infrastructure/Adapters/SlcanAdapter.cs
+++ b/infrastructure/Adapters/SlcanAdapter.cs
@@ -11,6 +11,11 @@ namespace infrastructure.Adapters;
 
 public class SlcanAdapter : ICommsAdapter
 {
+    // SLCAN runs over a relatively slow serial link (115200 by default).
+    // Short pacing helps prevent adapter/firmware buffer overruns during large bursts (e.g. WriteAll).
+    private const int MaxBufferedSerialBytes = 2048;
+    private const int InterFrameDelayMs = 2;
+
     public virtual string Name => "SLCAN";
 
     protected SerialPort? Serial;
@@ -189,11 +194,25 @@ public class SlcanAdapter : ICommsAdapter
         var frameBuffer = new byte[22];
         try
         {
-            foreach (var frame in frames)
+            for (var i = 0; i < frames.Count; i++)
             {
-                if (frame.Payload.Length != 8) continue;
+                if (ct.IsCancellationRequested) return Task.FromResult(false);
+
+                var frame = frames[i];
+                if (frame.Payload.Length != 8) return Task.FromResult(false);
+
+                while (Serial is { IsOpen: true } && Serial.BytesToWrite > MaxBufferedSerialBytes)
+                {
+                    if (ct.IsCancellationRequested) return Task.FromResult(false);
+                    Thread.Sleep(1);
+                }
+
                 var len = EncodeFrame(frame, frameBuffer, 0);
                 Serial!.Write(frameBuffer, 0, len);
+
+                // Keep bursts within what common SLCAN firmware can reliably drain.
+                if (i < frames.Count - 1)
+                    Thread.Sleep(InterFrameDelayMs);
             }
         }
         catch (InvalidOperationException)

--- a/infrastructure/BackgroundServices/CommsDataPipeline.cs
+++ b/infrastructure/BackgroundServices/CommsDataPipeline.cs
@@ -76,19 +76,26 @@ public class CommsDataPipeline(
     {
         logger.LogInformation("RX Pipeline started");
 
-        await foreach (var frame in _rxChannel.Reader.ReadAllAsync(ct))
+        try
         {
-            try
+            await foreach (var frame in _rxChannel.Reader.ReadAllAsync(ct))
             {
-                msgLogger.Log(DataDirection.Rx, frame);
-                
-                // Route frame to DeviceManager, passes to all devices so they can update their state/config
-                deviceManager.OnCanDataReceived(frame);
+                try
+                {
+                    msgLogger.Log(DataDirection.Rx, frame);
+
+                    // Route frame to DeviceManager, passes to all devices so they can update their state/config
+                    deviceManager.OnCanDataReceived(frame);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Error processing RX frame: {CanId:X}", frame.Id);
+                }
             }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error processing RX frame: {CanId:X}", frame.Id);
-            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during host shutdown/cancellation.
         }
 
         logger.LogInformation("RX Pipeline stopped");

--- a/run-local.ps1
+++ b/run-local.ps1
@@ -1,0 +1,42 @@
+param(
+    [string]$ProjectPath = ".\web\web.csproj",
+    [string]$EnvironmentName = "Development"
+)
+
+$ErrorActionPreference = "Stop"
+$env:ASPNETCORE_ENVIRONMENT = $EnvironmentName
+
+function Resolve-DotnetWithNet10 {
+    $candidates = @(
+        "$env:ProgramFiles\dotnet\dotnet.exe",
+        "${env:ProgramFiles(x86)}\dotnet\dotnet.exe"
+    ) | Where-Object { Test-Path $_ }
+
+    foreach ($candidate in $candidates) {
+        $sdks = & $candidate --list-sdks 2>$null
+        if ($LASTEXITCODE -ne 0) { continue }
+        if ($sdks -match '^\s*10\.') {
+            return $candidate
+        }
+    }
+
+    $commandDotnet = (Get-Command dotnet -ErrorAction SilentlyContinue).Source
+    if ($commandDotnet) {
+        $sdks = & $commandDotnet --list-sdks 2>$null
+        if (($LASTEXITCODE -eq 0) -and ($sdks -match '^\s*10\.')) {
+            return $commandDotnet
+        }
+    }
+
+    return $null
+}
+
+$dotnetExe = Resolve-DotnetWithNet10
+if (-not $dotnetExe) {
+    Write-Error "No .NET 10 SDK found. Install .NET 10 SDK and ensure it is available under Program Files\dotnet."
+    exit 1
+}
+
+Write-Host "Using dotnet: $dotnetExe" -ForegroundColor Cyan
+Write-Host "Running $ProjectPath (ASPNETCORE_ENVIRONMENT=$EnvironmentName)..." -ForegroundColor Cyan
+& $dotnetExe run --project $ProjectPath

--- a/sync-testing-branch.ps1
+++ b/sync-testing-branch.ps1
@@ -1,0 +1,36 @@
+param(
+    [string]$RepoUrl = "https://github.com/corygrant/dingoConfig.git",
+    [string]$Branch = "testing",
+    [string]$TargetPath = "$HOME\dingoConfig"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Syncing repository from $RepoUrl ($Branch) to $TargetPath" -ForegroundColor Cyan
+
+if (-not (Test-Path $TargetPath)) {
+    git clone --branch $Branch --single-branch $RepoUrl $TargetPath
+    Write-Host "Clone complete." -ForegroundColor Green
+    exit 0
+}
+
+Push-Location $TargetPath
+try {
+    if (-not (Test-Path ".git")) {
+        throw "Target path exists but is not a git repository: $TargetPath"
+    }
+
+    $remoteUrl = git remote get-url origin
+    if ($remoteUrl -ne $RepoUrl) {
+        throw "Origin remote mismatch. Expected '$RepoUrl' but got '$remoteUrl'"
+    }
+
+    git fetch origin
+    git checkout $Branch
+    git pull origin $Branch
+
+    Write-Host "Repository synced to latest origin/$Branch." -ForegroundColor Green
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- Fixes CAN write reliability issues that caused partial `WriteAll` delivery and downstream count/CRC mismatch failures (for example `108 vs 133`) under high-burst traffic.
- Improves adapter transmit robustness by adding strict batch failure handling for PCAN and pacing/backpressure for SLCAN/USB serial writes.
- Improves legacy CANBoard compatibility by reducing false warning noise on older firmware and adding fallback handling for legacy cyclic CAN ID layout.

### Write reliability (PDM and similar configurable devices)
- `infrastructure/Adapters/PcanAdapter.cs`
  - `WriteBatchAsync` now checks each frame send result and fails the batch immediately if a single frame fails.
  - Prevents silent partial success reporting.
- `infrastructure/Adapters/SlcanAdapter.cs`
  - Added inter-frame pacing and serial backpressure in `WriteBatchAsync`.
  - Helps prevent adapter/firmware serial buffer overruns during large bursts (`WriteAllVal` sequences).
  - USB path benefits automatically because `UsbAdapter` inherits `SlcanAdapter`.
  
  ### Pipeline/debug stability
- `infrastructure/BackgroundServices/CommsDataPipeline.cs`
  - Handles expected `OperationCanceledException` in RX loop during shutdown/cancel, matching TX-side behavior and avoiding noisy debug breakpoints.

### Legacy CANBoard behavior
- `domain/Devices/FwDevice.cs`
  - `ConfigMismatch` no longer defaults to `true`; prevents false-positive mismatch state when older firmware does not support CRC response.
  - CANBoard version request now uses fire-and-forget behavior for legacy firmware that does not respond to version query.
  - Added automatic fallback for legacy CANBoard cyclic ID layout (`baseId` vs `baseId + 2` start), fixing signal misalignment symptoms (for example heartbeat appearing under analog input).

### Local dev setup (supporting changes)
- `.vscode/launch.json`
  - Fixed launch target DLL from `web.dll` to `dingoConfig.dll`.
- `.vscode/tasks.json`
  - Added/updated helper tasks for sync/build/run/check-dotnet flows.
- Added helper scripts:
  - `sync-testing-branch.ps1`
  - `build-local.ps1`
  - `run-local.ps1`
  - `check-dotnet.ps1`
- `README.md`
  - Added local VS Code build/run instructions.
  
 ## Root cause
Large parameter writes were vulnerable to transport-layer frame loss in batch transmit paths. On PCAN, frame-level failures could be masked at batch level; on SLCAN/USB, burst rate could exceed practical serial/adapter buffering. The device then received incomplete `WriteAllVal` sets, causing expected count/CRC validation failure at completion.

## Validation / Test plan
- [x] Build succeeds on `net10.0`.
- [x] PDM `Write`/`WriteAll` + `Burn` complete successfully in testing where failures were previously observed.
- [x] No recurring `Write All Failed ... <received vs expected>` mismatch in the verified scenario.
- [x] Legacy CANBoard no longer spams version retry/fail logs in read-only usage.
- [x] CANBoard cyclic values decode correctly with legacy ID layout fallback (no heartbeat/analog mis-mapping symptom).